### PR TITLE
OAuth Client Credentials grant type support

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -71,8 +71,8 @@ TEMPLATES = [
     },
 ]
 MIDDLEWARE = (
-    'django.middleware.gzip.GZipMiddleware',
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.gzip.GZipMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',
@@ -107,7 +107,6 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework_swagger',
     'drf_yasg',
-    'oauth2_jwt_provider',
     'crispy_forms',  # needed to squash warnings around collectstatic with rest_framework
     'corsheaders',
     'tos',
@@ -272,13 +271,17 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Allow super users to register applications for OAuth authentication
 OAUTH2_PROVIDER = {
+    'ALLOW_SUPERUSERS': True,
+    'DEVELOPER_GROUP': 'admin',
     'SCOPES': {
         'read': 'Read scope',
         'write': 'Write scope',
         'offline': 'Offline access',
     }
 }
+#OAUTH2_PROVIDER_APPLICATION_MODEL = 'helix.authentication.HELIXClientCredentialsOAuthApplication'
 
 AUTHENTICATION_BACKENDS = [
     'seed.authentication.SeedOpenIDAuthenticationBackend',
@@ -290,7 +293,7 @@ AUTHENTICATION_BACKENDS = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
-        'oauth2_provider.ext.rest_framework.OAuth2Authentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
         'rest_framework.authentication.SessionAuthentication',
         'seed.authentication.SEEDAuthentication',
     ),
@@ -336,12 +339,6 @@ SWAGGER_SETTINGS = {
 # GREEN_ASSESSMENT_DEFAULT_VALIDITY_DURATION=5 * 365
 GREEN_ASSESSMENT_DEFAULT_VALIDITY_DURATION = None
 
-# Allow super users to register applications for OAuth authentication
-OAUTH2_PROVIDER = {
-    'ALLOW_SUPERUSERS': True,
-    'DEVELOPER_GROUP': 'admin',
-}
-
 OIDC_OP_AUTHORIZATION_ENDPOINT = 'https://sparkplatform.com/openid/authorize'
 OIDC_OP_TOKEN_ENDPOINT = 'https://sparkplatform.com/openid/token'
 OIDC_OP_USER_ENDPOINT = 'https://sparkplatform.com/openid/userinfo'
@@ -354,4 +351,4 @@ OIDC_SEED_ORG = 'Spark'
 FORCE_SSL_PROTOCOL = False
 
 # There are publicly available API endpoints
-CORS_ALL_ALL_ORIGINS = True
+CORS_ALLOW_ALL_ORIGINS = True

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -281,7 +281,6 @@ OAUTH2_PROVIDER = {
         'offline': 'Offline access',
     }
 }
-#OAUTH2_PROVIDER_APPLICATION_MODEL = 'helix.authentication.HELIXClientCredentialsOAuthApplication'
 
 AUTHENTICATION_BACKENDS = [
     'seed.authentication.SeedOpenIDAuthenticationBackend',

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -72,6 +72,7 @@ TEMPLATES = [
 ]
 MIDDLEWARE = (
     'django.middleware.gzip.GZipMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',
@@ -108,6 +109,7 @@ INSTALLED_APPS = (
     'drf_yasg',
     'oauth2_jwt_provider',
     'crispy_forms',  # needed to squash warnings around collectstatic with rest_framework
+    'corsheaders',
     'tos',
     'mozilla_django_oidc',
 )
@@ -350,3 +352,6 @@ OIDC_SEED_ORG = 'Spark'
 # Determines if SEED respects request.scheme or assumes that things are using
 # HTTPS. This is useful for instances behind a reverse proxy that resolves SSL.
 FORCE_SSL_PROTOCOL = False
+
+# There are publicly available API endpoints
+CORS_ALL_ALL_ORIGINS = True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -77,12 +77,11 @@ mozilla-django-oidc
 -e git+https://github.com/SEED-platform/buildingid.git@f68219df82191563cc2aca818e0b0fa1b32dd52d#egg=buildingid
 
 enum34==1.1.6  # enum34 needs to be specified to support cryptography and oauth2
-oauthlib==2.0.2
+oauthlib>=3.1.0
 # cffi & cryptography dependencies needs to be installed via bitbucket/github due to a pip segfault with Python 3.6.7
 # -e hg+https://bitbucket.org/cffi/cffi@v1.11.5#egg=cffi
 # -e git+https://github.com/pyca/cryptography@2.5#egg=cryptography
-jwt-oauth2>=0.1.1
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit>=1.0.0
 
 future==0.18.2
 django-cors-headers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -85,3 +85,4 @@ jwt-oauth2>=0.1.1
 django-oauth-toolkit==0.12.0
 
 future==0.18.2
+django-cors-headers

--- a/seed/landing/models.py
+++ b/seed/landing/models.py
@@ -112,8 +112,7 @@ class SEEDUser(AbstractBaseUser, PermissionsMixin):
                 if not valid_api_key:
                     return None
 
-                user = SEEDUser.objects.get(api_key=api_key, username=username)
-                return user
+                return SEEDUser.objects.get(api_key=api_key, username=username)
             except ValueError:
                 raise exceptions.AuthenticationFailed('Invalid HTTP_AUTHORIZATION Header')
             except SEEDUser.DoesNotExist:

--- a/seed/utils/viewsets.py
+++ b/seed/utils/viewsets.py
@@ -17,7 +17,7 @@ parser_classes, authentication_classes, and pagination_classes attributes.
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
-from oauth2_provider.ext.rest_framework import OAuth2Authentication
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 
 # Local Imports
 from seed.authentication import SEEDAuthentication


### PR DESCRIPTION
This may cause issues with migrations as it bumps the Django oauth toolkit version and upstream squashed their migrations into a single migration. This migration includes a changes that we haven't yet applied, causes column does not exist errors at runtime.

The fix is to roll back the oauth2_provider changes and apply them again. This will lose all the associated DB data, so we will need to back up and restore that data. I need to experiment on staging and record the exact steps required