### PR TITLE
feat: allow apikey to be base64 encoded in the request query parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache python3-dev \
         geos \
         gdal \
         gcc \
+        git \
         musl-dev \
         cargo && \
     ln -sf /usr/bin/python3 /usr/bin/python && \

--- a/seed/authentication.py
+++ b/seed/authentication.py
@@ -21,7 +21,10 @@ class SEEDAuthentication(authentication.BaseAuthentication):
     """
 
     def authenticate(self, request):
-        return User.process_header_request(request), None  # return None per base class
+        header = User.process_header_request(request)
+        if header is None:
+            return User.process_query_request(request), None
+        return header, None  # return None per base class
 
 class SEEDKeyAuthentication:
     """


### PR DESCRIPTION
The request takes the form `/endpoint/?apikey=<base64 encoded username:apikey>`