### PR TITLE
comment out docker build caching from workflow

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -61,8 +61,8 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/helix:${{ steps.date.outputs.date }},
             ${{ steps.login-ecr.outputs.registry }}/helix:latest
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/helix:latest
-          cache-to: type=inline
+          #cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/helix:latest
+          #cache-to: type=inline
           secret-envs: |
             PIP_EXTRA_INDEX_URL=PIP_EXTRA_INDEX_URL
 


### PR DESCRIPTION
Temporarily avoid caching layers during docker build.

We need to allow newest version of HELIX to be installed during the build step. Later, HELIX will versioned similar to BEAM-OPT to allow caching.
